### PR TITLE
add pluginId

### DIFF
--- a/common/head_tag.html
+++ b/common/head_tag.html
@@ -1,6 +1,6 @@
 <script type="text/discourse-plugin" version="0.1">
     api.modifyClass('controller:topic', {
-       pluginId: 'md-composer-extras',
+       pluginId: 'discourse-admin-warnings',
        actions:{
            replyToPost(post, skipWarning = false) {
                 if((this.get('model.closed') || this.get('model.archived')) && !skipWarning){

--- a/common/head_tag.html
+++ b/common/head_tag.html
@@ -1,5 +1,6 @@
 <script type="text/discourse-plugin" version="0.1">
     api.modifyClass('controller:topic', {
+       pluginId: 'md-composer-extras',
        actions:{
            replyToPost(post, skipWarning = false) {
                 if((this.get('model.closed') || this.get('model.archived')) && !skipWarning){


### PR DESCRIPTION
fix To prevent errors in tests, add a `pluginId` key to your `modifyClass` call. This will ensure the modification is only applied once.
